### PR TITLE
Feature/error identifiers

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -230,6 +230,9 @@ const docTemplate = `{
             "properties": {
                 "error": {
                     "type": "string"
+                },
+                "error_id": {
+                    "type": "string"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -223,6 +223,9 @@
             "properties": {
                 "error": {
                     "type": "string"
+                },
+                "error_id": {
+                    "type": "string"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4,6 +4,8 @@ definitions:
     properties:
       error:
         type: string
+      error_id:
+        type: string
     type: object
   api.idResponse:
     properties:

--- a/cmd/api/product.go
+++ b/cmd/api/product.go
@@ -34,7 +34,8 @@ func getProducts(srv Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		products, err := srv.Storage().GetProducts()
 		if err != nil {
-			respondWithError(w, srv.Logger(), http.StatusInternalServerError, err.Error())
+			messages := []string{"Failed to get products", "get_products_error", err.Error()}
+			respondWithError(w, srv.Logger(), http.StatusInternalServerError, messages...)
 			return
 		}
 
@@ -57,7 +58,8 @@ func getProduct(srv Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := strconv.Atoi(chi.URLParam(r, "id"))
 		if err != nil {
-			respondWithError(w, srv.Logger(), http.StatusBadRequest, "Invalid parameter 'id'")
+			messages := []string{"Invalid parameter 'id'", "atoi_error", err.Error()}
+			respondWithError(w, srv.Logger(), http.StatusBadRequest, messages...)
 			return
 		}
 
@@ -68,7 +70,8 @@ func getProduct(srv Server) http.HandlerFunc {
 				respondWithError(w, srv.Logger(), http.StatusNotFound, "Product not found")
 				return
 			}
-			respondWithError(w, srv.Logger(), http.StatusInternalServerError, "Failed to get product: "+err.Error())
+			messages := []string{"Failed to get product", "get_product_error", err.Error()}
+			respondWithError(w, srv.Logger(), http.StatusInternalServerError, messages...)
 			return
 		}
 
@@ -91,14 +94,16 @@ func createProduct(srv Server) http.HandlerFunc {
 		var createProductReq models.CreateProductRequest
 		err := parseJSONBody(r, &createProductReq)
 		if err != nil {
-			respondWithError(w, srv.Logger(), http.StatusInternalServerError, "Failed to parse JSON payload: "+err.Error())
+			messages := []string{"Failed to parse JSON payload", "parse_json_body_error", err.Error()}
+			respondWithError(w, srv.Logger(), http.StatusInternalServerError, messages...)
 			return
 		}
 
 		var id int
 		id, err = srv.Storage().CreateProduct(&createProductReq)
 		if err != nil {
-			respondWithError(w, srv.Logger(), http.StatusInternalServerError, "Failed to create product: "+err.Error())
+			messages := []string{"Failed to create product", "create_product_error", err.Error()}
+			respondWithError(w, srv.Logger(), http.StatusInternalServerError, messages...)
 			return
 		}
 
@@ -122,21 +127,24 @@ func updateProduct(srv Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := strconv.Atoi(chi.URLParam(r, "id"))
 		if err != nil {
-			respondWithError(w, srv.Logger(), http.StatusBadRequest, "Invalid parameter 'id'")
+			messages := []string{"Invalid parameter 'id'", "atoi_error", err.Error()}
+			respondWithError(w, srv.Logger(), http.StatusBadRequest, messages...)
 			return
 		}
 
 		var createProductReq models.CreateProductRequest
 		err = parseJSONBody(r, &createProductReq)
 		if err != nil {
-			respondWithError(w, srv.Logger(), http.StatusInternalServerError, "Failed to parse JSON payload: "+err.Error())
+			messages := []string{"Failed to parse JSON payload", "parse_json_body_error", err.Error()}
+			respondWithError(w, srv.Logger(), http.StatusInternalServerError, messages...)
 			return
 		}
 
 		product := createProductReq.ToProduct(id)
 		err = srv.Storage().UpdateProduct(product)
 		if err != nil {
-			respondWithError(w, srv.Logger(), http.StatusInternalServerError, "Failed to update product: "+err.Error())
+			messages := []string{"Failed to update product", "update_product_error", err.Error()}
+			respondWithError(w, srv.Logger(), http.StatusInternalServerError, messages...)
 			return
 		}
 
@@ -157,13 +165,15 @@ func deleteProduct(srv Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := strconv.Atoi(chi.URLParam(r, "id"))
 		if err != nil {
-			respondWithError(w, srv.Logger(), http.StatusBadRequest, "Invalid parameter 'id'")
+			messages := []string{"Invalid parameter 'id'", "atoi_error", err.Error()}
+			respondWithError(w, srv.Logger(), http.StatusBadRequest, messages...)
 			return
 		}
 
 		err = srv.Storage().DeleteProduct(id)
 		if err != nil {
-			respondWithError(w, srv.Logger(), http.StatusInternalServerError, "Failed to delete product: "+err.Error())
+			messages := []string{"Failed to delete product", "delete_product_error", err.Error()}
+			respondWithError(w, srv.Logger(), http.StatusInternalServerError, messages...)
 			return
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-openapi/swag v0.22.4 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/oklog/ulid/v2 v2.1.0 // indirect
 	github.com/swaggo/files v1.0.1 // indirect
 	golang.org/x/net v0.14.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,9 @@ github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
+github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/internal/config/logger.go
+++ b/internal/config/logger.go
@@ -84,6 +84,11 @@ func (l *Log) createLog(level, msg string, args ...interface{}) {
 
 	// Loop through all args and format them as key-value pairs.
 	for i := 0; i < len(args); i += 2 {
+		// If there is an odd number of args, the last one is a value with an unknown key.
+		if i == len(args)-1 {
+			fmt.Fprintf(w, ",\t%v: %v", "odd_args_key", args[i])
+			continue
+		}
 		fmt.Fprintf(w, ",\t%v: %v", args[i], args[i+1])
 	}
 


### PR DESCRIPTION
Features:
- Handler error logging is now delegated to the `createErrorResponse` helper. The exception to this is when an error has occurred when trying to use the helper. An example of this exception can be seen in the `respondWithJSON` handler helper.
- Error responses & logs now have error IDs of type ULID allowing association of responses to logs
- Swagger docs updated to include the new error ID field in `errorResponse` types.
- `respondWithError` handler helper now accepts a variadic number of error messages. These are given to the `createErrorResponse` helper which: generates an error ID, creates a response with said ID and first message, logs ID and all messages, returns the response.

Fixes:
- Custom `Log` type now handles odd number of arguments by creating the last key-value pair using the key "odd_args_key" and the value of the final argument. 
